### PR TITLE
修复在线铺面卡片难度排序与详情滚动

### DIFF
--- a/src/features/online-beatmaps/BeatmapsetCard.test.tsx
+++ b/src/features/online-beatmaps/BeatmapsetCard.test.tsx
@@ -85,4 +85,40 @@ describe("BeatmapsetCard", () => {
     await user.keyboard("{Enter}");
     expect(onOpen).toHaveBeenCalledOnce();
   });
+
+  it("sorts every difficulty by stars and keeps hover details scrollable", () => {
+    const difficulties = [
+      { id: 701, difficulty_rating: 7.07, version: "Extra" },
+      { id: 593, difficulty_rating: 5.93, version: "Another" },
+      { id: 467, difficulty_rating: 4.67, version: "Insane" },
+      { id: 338, difficulty_rating: 3.38, version: "Hard" },
+      { id: 249, difficulty_rating: 2.49, version: "Normal" },
+      { id: 810, difficulty_rating: 8.10, version: "Expert" },
+    ].map((difficulty) => ({
+      ...beatmapset.beatmaps![0],
+      ...difficulty,
+    }));
+
+    const { container } = render(
+      <BeatmapsetCard
+        beatmapset={{ ...beatmapset, beatmaps: difficulties }}
+        downloading={false}
+        onDownload={vi.fn()}
+        onOpen={vi.fn()}
+        onPreview={vi.fn()}
+        onSelect={vi.fn()}
+        playing={false}
+        selected={false}
+      />,
+    );
+
+    const compact = container.querySelector(".opp-beatmap-card__difficulty-list");
+    const details = container.querySelector(".opp-beatmap-card__details");
+    const detailDifficulties = container.querySelector(".opp-beatmap-card__detail-difficulties");
+    const ratings = (root: Element | null) => Array.from(root?.querySelectorAll('[title$=" stars"]') ?? [], (node) => node.textContent?.trim());
+
+    expect(ratings(compact)).toEqual(["2.49", "3.38", "4.67", "5.93", "7.07"]);
+    expect(ratings(detailDifficulties)).toEqual(["2.49", "3.38", "4.67", "5.93", "7.07", "8.10"]);
+    expect(details).toHaveClass("overflow-y-auto", "overscroll-contain", "group-hover:pointer-events-auto");
+  });
 });

--- a/src/features/online-beatmaps/BeatmapsetCard.tsx
+++ b/src/features/online-beatmaps/BeatmapsetCard.tsx
@@ -34,7 +34,10 @@ function statusLabel(status: string) {
 
 export function BeatmapsetCard({ beatmapset, downloading, playing, selected, onAddToCollection = () => undefined, onDownload, onOpen, onPreview, onSelect }: { beatmapset: OnlineBeatmapset; downloading: boolean; playing: boolean; selected: boolean; onAddToCollection?: () => void; onDownload: () => void; onOpen: () => void; onPreview: () => void; onSelect: () => void }) {
   const preview = normalizePreviewUrl(beatmapset.preview_url);
-  const beatmaps = beatmapset.beatmaps ?? [];
+  // 卡片内外复用同一份升序结果，避免接口顺序导致难度展示跳跃。
+  const beatmaps = [...(beatmapset.beatmaps ?? [])].sort((left, right) =>
+    left.difficulty_rating - right.difficulty_rating || left.id - right.id,
+  );
   const longest = Math.max(0, ...beatmaps.map((beatmap) => beatmap.total_length ?? 0));
   const minStars = beatmaps.length ? Math.min(...beatmaps.map((beatmap) => beatmap.difficulty_rating)) : 0;
   const maxStars = beatmaps.length ? Math.max(...beatmaps.map((beatmap) => beatmap.difficulty_rating)) : 0;
@@ -89,7 +92,7 @@ export function BeatmapsetCard({ beatmapset, downloading, playing, selected, onA
           {beatmapset.video ? <Badge>VIDEO</Badge> : null}
           {disabled ? <Badge tone="warning">禁止下载</Badge> : null}
         </div>
-        <div className="flex min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap">
+        <div className="opp-beatmap-card__difficulty-list flex min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap">
           <span className="mr-1 shrink-0 text-[11px] font-semibold text-slate-400">难度</span>
           {beatmaps.slice(0, 5).map((beatmap) => <span className="inline-flex min-w-0 items-center gap-1.5" key={beatmap.id}><DifficultyIcon className="px-1.5 py-0.5" mode={beatmap.mode} stars={beatmap.difficulty_rating} /><span className="opp-beatmap-card__difficulty-name max-w-24 truncate text-[11px] text-slate-200">{beatmap.version}</span></span>)}
           {beatmaps.length > 5 ? <span className="text-[11px] font-medium text-slate-400">+{beatmaps.length - 5}</span> : null}
@@ -98,11 +101,11 @@ export function BeatmapsetCard({ beatmapset, downloading, playing, selected, onA
     </div>
 
     {/* 悬停层随卡片比例定位，窗口缩放时保持一致的信息占比。 */}
-    <div aria-hidden="true" className="opp-beatmap-card__details pointer-events-none absolute inset-x-0 bottom-0 top-[40%] z-20 translate-y-2.5 border-t border-white/[.08] bg-[linear-gradient(180deg,rgba(21,25,31,.97),rgba(13,16,21,.99))] p-[14px_16px] opacity-0 [transition:opacity_var(--motion-base)_ease,transform_var(--motion-base)_cubic-bezier(.2,.8,.2,1)] group-hover:translate-y-0 group-hover:opacity-100 group-focus-within:translate-y-0 group-focus-within:opacity-100 motion-reduce:transition-none">
+    <div aria-hidden="true" className="opp-beatmap-card__details pointer-events-none absolute inset-x-0 bottom-0 top-[40%] z-20 translate-y-2.5 overflow-y-auto overscroll-contain border-t border-white/[.08] bg-[linear-gradient(180deg,rgba(21,25,31,.97),rgba(13,16,21,.99))] p-[14px_16px] opacity-0 [transition:opacity_var(--motion-base)_ease,transform_var(--motion-base)_cubic-bezier(.2,.8,.2,1)] group-hover:pointer-events-auto group-hover:translate-y-0 group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:translate-y-0 group-focus-within:opacity-100 motion-reduce:transition-none">
       <div className="opp-beatmap-card__metrics grid grid-cols-6 gap-x-2">
         {[{ label: "星级", value: `${minStars.toFixed(2)}–${maxStars.toFixed(2)}★` }, { label: "BPM", value: String(Math.round(beatmapset.bpm ?? 0)) }, { label: "长度", value: durationLabel(longest) }, { label: "物件", value: fullNumber(objects) }, { label: "游玩", value: fullNumber(beatmapset.play_count ?? 0) }, { label: "上架", value: dateLabel(beatmapset.ranked_date) }].map((metric) => <div className="min-w-0" key={metric.label}><p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-slate-500">{metric.label}</p><p className="mt-0.5 truncate text-xs font-semibold text-slate-100">{metric.value}</p></div>)}
       </div>
-      <div className="mt-3 flex max-h-[34%] flex-wrap content-start gap-1.5 overflow-hidden">
+      <div className="opp-beatmap-card__detail-difficulties mt-3 flex flex-wrap content-start gap-1.5">
         {beatmaps.map((beatmap) => <span className="inline-flex min-w-0 items-center gap-1 rounded-md border border-white/10 bg-black/20 pr-2" key={beatmap.id}><DifficultyIcon className="border-0 bg-transparent px-1.5 py-1" mode={beatmap.mode} stars={beatmap.difficulty_rating} /><span className="max-w-28 truncate text-[11px] text-slate-200">{beatmap.version}</span></span>)}
       </div>
     </div>


### PR DESCRIPTION
## 改动内容

- `src/features/online-beatmaps/BeatmapsetCard.tsx`：复制并按星数升序排列难度，外层摘要与悬浮详情复用同一顺序；让悬浮详情支持纵向滚动，并限制滚动不传递到页面。
- `src/features/online-beatmaps/BeatmapsetCard.test.tsx`：补充乱序、多难度场景的排序与滚动能力回归测试。

## 目的

- 保证卡片外层难度始终从低星到高星展示。
- 谱面集难度较多时，可在悬浮详情内使用鼠标滚轮或触控板查看全部难度。
- 按最新确认，不修改收藏夹卡片的数据模型和星数显示。

## 验证

- `pnpm lint`
- `pnpm test`（37 个测试文件、105 个测试通过）
- `pnpm build`