### PR TITLE
修复在线筛选间距并统一本地铺面卡片布局

### DIFF
--- a/src/features/local-analysis/BeatmapSetPanel.test.tsx
+++ b/src/features/local-analysis/BeatmapSetPanel.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { LocalBeatmapSetSummary, LocalBeatmapSummary } from "../../shared/types/osu";
+import { useLocalBeatmapBackground, useLocalBeatmapSets } from "./api";
+import { BeatmapSetPanel } from "./BeatmapSetPanel";
+
+vi.mock("./api", () => ({
+  useLocalBeatmapBackground: vi.fn(),
+  useLocalBeatmapSets: vi.fn(),
+}));
+
+function difficulty(id: string, stars: number, name: string): LocalBeatmapSummary {
+  return {
+    resource: { resource_id: id, client: "stable", content_hash: `hash-${id}`, logical_path: `Songs/${id}` },
+    set_key: "set-1",
+    set_grouping_inferred: false,
+    beatmap_id: Number(id),
+    beatmap_set_id: 456,
+    title: "Local Song",
+    title_unicode: "",
+    artist: "Local Artist",
+    artist_unicode: "",
+    creator: "Local Mapper",
+    difficulty_name: name,
+    ruleset: "osu",
+    format_version: 14,
+    stars,
+    max_pp: 300,
+    max_combo: 500,
+    bpm: 180,
+    length_ms: 120_000,
+    object_count: 500,
+    cs: 4,
+    ar: 9,
+    od: 8,
+    hp: 6,
+    average_nps: 4.2,
+    peak_nps: 7.1,
+    modified_at: null,
+    analysis_status: "ready",
+  };
+}
+
+const set: LocalBeatmapSetSummary = {
+  set_key: "set-1",
+  completeness: "complete",
+  grouping_inferred: false,
+  beatmap_set_id: 456,
+  title: "Local Song",
+  title_unicode: "",
+  artist: "Local Artist",
+  artist_unicode: "",
+  creators: ["Local Mapper"],
+  min_stars: 2.1,
+  max_stars: 5.4,
+  bpm: 180,
+  length_ms: 120_000,
+  object_count: 500,
+  modified_at: null,
+  background_resource_id: "501",
+  difficulties: [difficulty("502", 5.4, "Insane"), difficulty("501", 2.1, "Easy")],
+};
+
+describe("BeatmapSetPanel", () => {
+  beforeEach(() => {
+    vi.mocked(useLocalBeatmapBackground).mockReturnValue({ data: "data:image/png;base64,cover" } as never);
+    vi.mocked(useLocalBeatmapSets).mockReturnValue({
+      data: { items: [set], total: 1, offset: 0, limit: 40 },
+      error: null,
+      isLoading: false,
+      refetch: vi.fn(),
+    } as never);
+  });
+
+  it("uses the online beatmap grid and media-card language for local sets", async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    const { container } = render(<BeatmapSetPanel client="stable" onOpen={onOpen} ruleset="osu" />);
+
+    expect(container.querySelector(".opp-local-results")).toHaveClass("opp-online-results");
+    expect(container.querySelector(".opp-local-results-grid")).toHaveClass("opp-online-results-grid");
+    const card = screen.getByRole("button", { name: "查看本地谱面集 Local Song" });
+    expect(card).toHaveClass("opp-media-card", "opp-beatmap-card", "aspect-[136/55]", "rounded-xl");
+    expect(card.querySelector(".opp-beatmap-card__cover-overlay")).toBeInTheDocument();
+    expect(card.querySelector(".opp-beatmap-card__details")).toBeInTheDocument();
+
+    const compactRatings = Array.from(card.querySelectorAll('.opp-beatmap-card__difficulty-list [title$=" stars"]'), (node) => node.textContent?.trim());
+    expect(compactRatings).toEqual(["2.10", "5.40"]);
+
+    await user.click(card);
+    expect(screen.getByRole("dialog")).toBeVisible();
+    expect(screen.getByRole("heading", { name: "Local Song" })).toBeVisible();
+  });
+});

--- a/src/features/local-analysis/BeatmapSetPanel.tsx
+++ b/src/features/local-analysis/BeatmapSetPanel.tsx
@@ -37,7 +37,6 @@ import {
   Skeleton,
 } from "../../shared/components/ui";
 import { SearchAutocomplete } from "../../shared/components/SearchAutocomplete";
-import { BeatmapDifficultyStrip, BeatmapInfoBar } from "../../shared/components/BeatmapSetVisuals";
 import { errorMessage, fullNumber, rulesetLabels } from "../../shared/lib/format";
 import { desktopApi } from "../../shared/lib/tauri";
 import { DifficultyIcon, ModeIcon } from "../online-beatmaps/BeatmapVisuals";
@@ -55,6 +54,7 @@ import {
   useLocalBeatmapBackground,
   useLocalBeatmapSets,
 } from "./api";
+import "../../shared/styles/beatmapCards.css";
 
 interface RangeValues {
   minStars: string;
@@ -140,11 +140,11 @@ function SetBackground({
   return query.data ? (
     <img
       alt=""
-      className="theme-beatmap-background absolute inset-0 size-full object-cover opacity-55"
+      className="opp-media-card__cover theme-beatmap-background absolute inset-0 size-full scale-[1.015] object-cover opacity-[.58] saturate-[.9] contrast-[1.06] [transition:transform_420ms_cubic-bezier(.2,.8,.2,1),opacity_var(--motion-base)_ease] group-hover:scale-[1.045] group-hover:opacity-[.72] motion-reduce:transition-none"
       src={query.data}
     />
   ) : (
-    <div className="theme-beatmap-background absolute inset-0 bg-[radial-gradient(circle_at_80%_20%,rgba(92,225,230,.16),transparent_32%),radial-gradient(circle_at_15%_80%,rgba(255,106,167,.18),transparent_36%)]" />
+    <div className="opp-media-card__cover theme-beatmap-background absolute inset-0 bg-[radial-gradient(circle_at_80%_20%,rgba(92,225,230,.16),transparent_32%),radial-gradient(circle_at_15%_80%,rgba(255,106,167,.18),transparent_36%)]" />
   );
 }
 
@@ -224,112 +224,82 @@ function BeatmapSetCard({
     }
   };
   const starRange =
-    set.min_stars === null
+    set.min_stars === null || set.max_stars === null
       ? "待计算"
       : set.min_stars === set.max_stars
         ? `${set.min_stars.toFixed(2)}★`
         : `${set.min_stars.toFixed(2)}–${set.max_stars?.toFixed(2)}★`;
-  const peakNps = Math.max(...set.difficulties.map((item) => item.peak_nps), 0);
+  // 本地谱面与在线谱面保持相同的低星到高星阅读顺序，空星数放在末尾。
+  const difficulties = [...set.difficulties].sort((left, right) =>
+    (left.stars ?? Number.POSITIVE_INFINITY) - (right.stars ?? Number.POSITIVE_INFINITY)
+      || left.difficulty_name.localeCompare(right.difficulty_name),
+  );
+  const peakNps = Math.max(...difficulties.map((item) => item.peak_nps), 0);
+  const title = set.title_unicode || set.title;
+  const artist = set.artist_unicode || set.artist;
+  const statusMessage = neteaseError ? errorMessage(neteaseError) : exportNotice;
 
   return (
     <>
-    <article className="overflow-hidden rounded-[22px] border border-white/[0.075] bg-[#0f1522] shadow-[0_16px_45px_rgba(0,0,0,.16)] transition hover:border-white/[0.14]">
-      <div className="relative min-h-40 overflow-hidden">
+      <Card
+        aria-label={`查看本地谱面集 ${title}`}
+        className="opp-media-card opp-beatmap-card opp-local-beatmap-card group relative isolate aspect-[136/55] min-h-40 min-w-0 cursor-pointer overflow-hidden rounded-xl border border-[var(--line-strong)] bg-[#1a1e24] shadow-[0_8px_22px_rgba(0,0,0,0.14)] outline-none transition-[border-color,box-shadow,transform] duration-[var(--motion-base)] ease-[cubic-bezier(.2,.8,.2,1)] hover:-translate-y-0.5 hover:border-[var(--theme-primary-soft)] hover:shadow-[0_16px_34px_rgba(0,0,0,0.22)] focus-visible:ring-2 focus-visible:ring-[var(--theme-primary-soft)] motion-reduce:transition-none"
+        onClick={() => setDifficultyDialogOpen(true)}
+        onKeyDown={(event) => { if (event.key === "Enter" && event.target === event.currentTarget) setDifficultyDialogOpen(true); }}
+        role="button"
+        tabIndex={0}
+        unstyled
+      >
         <SetBackground client={client} resourceId={set.background_resource_id} />
-        <div className="theme-beatmap-overlay-primary absolute inset-0 bg-gradient-to-r from-[#0b101b]/95 via-[#0b101b]/76 to-[#0b101b]/35" />
-        <div className="theme-beatmap-overlay-secondary absolute inset-0 bg-gradient-to-t from-[#0f1522] via-transparent to-black/20" />
-        <div className="relative flex min-h-40 items-end gap-6 p-5">
-          <div className="min-w-0 flex-1">
-            <div className="mb-3 flex flex-wrap items-center gap-2">
-              <Badge tone={set.beatmap_set_id ? "success" : "neutral"}>
-                {set.beatmap_set_id ? `SET ${set.beatmap_set_id}` : "LOCAL SET"}
-              </Badge>
-              {set.grouping_inferred ? <Badge tone="warning">推断分组</Badge> : null}
-              <Badge tone="cyan">{set.difficulties.length} 个匹配难度</Badge>
-            </div>
-            <h3 className="truncate text-xl font-semibold tracking-tight text-white">
-              {set.title_unicode || set.title}
-            </h3>
-            <p className="mt-1.5 truncate text-sm text-slate-300">
-              {set.artist_unicode || set.artist}
-            </p>
-            <p className="mt-2 truncate text-xs text-slate-500">
-              mapped by <span className="text-slate-300">{set.creators.join(" · ")}</span>
-            </p>
-          </div>
-          <BeatmapInfoBar metrics={[{ label: "Star range", value: starRange }, { label: "BPM", value: set.bpm.toFixed(0) }, { label: "Length", value: formatDuration(set.length_ms) }, { label: "Objects", value: fullNumber(set.object_count) }, { label: "Peak NPS", value: peakNps.toFixed(1) }, { label: "Difficulties", value: String(set.difficulties.length) }]} />
-        </div>
-      </div>
+        <div className="opp-beatmap-card__cover-overlay absolute inset-0 z-[2] bg-[linear-gradient(90deg,rgba(17,20,25,.96),rgba(22,26,32,.82)_62%,rgba(22,26,32,.67)),linear-gradient(0deg,rgba(10,12,16,.72),transparent_70%)]" />
 
-      <div className="flex items-center gap-2 border-t border-white/[0.055] bg-black/10 px-5 py-3">
-        <div className="min-w-0 flex-1">
-          <BeatmapDifficultyStrip difficulties={set.difficulties.map((difficulty) => ({ id: difficulty.resource.resource_id, mode: difficulty.ruleset, stars: difficulty.stars, label: difficulty.difficulty_name, onClick: () => onOpen(difficulty.resource.resource_id) }))} />
+        <div className="opp-beatmap-card__body relative z-10 flex h-full flex-col p-4">
+          <div className="opp-beatmap-card__header flex items-start gap-3">
+            <div className="min-w-0 flex-1">
+              <h3 className="opp-beatmap-card__title truncate text-[16px] font-semibold leading-5 tracking-[-0.01em] text-white">{title}</h3>
+              <p className="mt-0.5 truncate text-[13px] font-medium text-slate-300">{artist}</p>
+              <p className="mt-1.5 truncate text-xs text-slate-400">谱师 · <strong className="font-semibold text-slate-200">{set.creators.join(" · ") || "未知"}</strong></p>
+            </div>
+            <div className="opp-beatmap-card__actions relative z-30 flex shrink-0 gap-0.5">
+              {client === "stable" ? (
+                <Button aria-label="在资源管理器中打开谱面" disabled={!difficulties[0]?.resource.logical_path} onClick={(event) => { event.stopPropagation(); const path = difficulties[0]?.resource.logical_path; if (path) void desktopApi.openLocalResourceInExplorer(client, path); }} size="icon" title="打开文件" variant="ghost"><FolderSearch className="size-4" /></Button>
+              ) : (
+                // Lazer 文件按哈希散落存储，没有可打开的谱面集目录，直接提供导出。
+                <Button aria-label="导出为 .osz 谱面包" disabled={exporting} loading={exporting} onClick={(event) => { event.stopPropagation(); void exportOsz(); }} size="icon" title="导出 .osz" variant="ghost">{exporting ? null : <PackageOpen className="size-4" />}</Button>
+              )}
+              {set.beatmap_set_id ? <Button aria-label="在 osu! 官网打开谱面" onClick={(event) => { event.stopPropagation(); void desktopApi.openExternal(`https://osu.ppy.sh/beatmapsets/${set.beatmap_set_id}`); }} size="icon" title="打开官网" variant="ghost"><ExternalLink className="size-4" /></Button> : null}
+              <Button aria-label="在浏览器中搜索网易云音乐" onClick={(event) => { event.stopPropagation(); setNeteaseError(null); void desktopApi.openNeteaseMusicSearch(artist, title).catch(setNeteaseError); }} size="icon" title="搜索网易云音乐" variant="ghost"><Music4 className="size-4" /></Button>
+              <Button aria-label="查看难度" onClick={(event) => { event.stopPropagation(); setDifficultyDialogOpen(true); }} size="icon" title="查看难度" variant="ghost"><ListMusic className="size-4" /></Button>
+            </div>
+          </div>
+
+          <div className="mt-auto">
+            <div className="opp-beatmap-card__badges mb-3 flex flex-wrap items-center gap-2">
+              <Badge tone={set.beatmap_set_id ? "success" : "neutral"}>{set.beatmap_set_id ? "已提交" : "本地谱面"}</Badge>
+              <Badge tone="cyan">{difficulties.length} 个难度</Badge>
+              {set.grouping_inferred ? <Badge tone="warning">推断分组</Badge> : null}
+            </div>
+            <div className="opp-beatmap-card__difficulty-list flex min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap">
+              <span className="mr-1 shrink-0 text-[11px] font-semibold text-slate-400">难度</span>
+              {difficulties.slice(0, 5).map((difficulty) => <button className="inline-flex min-w-0 items-center gap-1.5 outline-none hover:brightness-110" key={difficulty.resource.resource_id} onClick={(event) => { event.stopPropagation(); onOpen(difficulty.resource.resource_id); }} type="button"><DifficultyIcon className="px-1.5 py-0.5" mode={difficulty.ruleset} stars={difficulty.stars} /><span className="opp-beatmap-card__difficulty-name max-w-24 truncate text-[11px] text-slate-200">{difficulty.difficulty_name}</span></button>)}
+              {difficulties.length > 5 ? <span className="text-[11px] font-medium text-slate-400">+{difficulties.length - 5}</span> : null}
+            </div>
+          </div>
         </div>
-        {client === "stable" ? (
-          <Button
-            aria-label="在资源管理器中打开谱面"
-            disabled={!set.difficulties[0]?.resource.logical_path}
-            onClick={() => { const path = set.difficulties[0]?.resource.logical_path; if (path) void desktopApi.openLocalResourceInExplorer(client, path); }}
-            size="sm"
-          >
-            <FolderSearch className="size-3.5" />
-            打开文件
-          </Button>
-        ) : (
-          // Lazer 文件按哈希散落存储，没有可打开的谱面集目录，直接提供导出。
-          <Button
-            aria-label="导出为 .osz 谱面包"
-            disabled={exporting}
-            loading={exporting}
-            onClick={() => void exportOsz()}
-            size="sm"
-            variant="primary"
-          >
-            <PackageOpen className="size-3.5" />
-            导出 .osz
-          </Button>
-        )}
-        {exportNotice ? <span className="max-w-56 truncate text-[11px] text-slate-500" title={exportNotice}>{exportNotice}</span> : null}
-        {set.beatmap_set_id ? (
-          <Button
-            aria-label="在 osu! 官网打开谱面"
-            onClick={() => void desktopApi.openExternal(
-              `https://osu.ppy.sh/beatmapsets/${set.beatmap_set_id}`,
-            )}
-            size="sm"
-            variant="secondary"
-          >
-            <ExternalLink className="size-3.5" />
-            打开官网
-          </Button>
-        ) : null}
-        <Button
-          aria-label="在浏览器中搜索网易云音乐"
-          onClick={() => {
-            setNeteaseError(null);
-            void desktopApi
-              .openNeteaseMusicSearch(set.artist_unicode || set.artist, set.title_unicode || set.title)
-              .catch(setNeteaseError);
-          }}
-          size="sm"
-          variant="secondary"
-        >
-          <Music4 className="size-3.5" />
-          搜索网易云音乐
-        </Button>
-        <Button
-          aria-haspopup="dialog"
-          onClick={() => setDifficultyDialogOpen(true)}
-          className="ml-auto shrink-0"
-          size="sm"
-        >
-          <ListMusic className="size-3.5" />
-          查看难度
-        </Button>
-      </div>
-      {neteaseError ? <p className="border-t border-rose-300/15 bg-rose-300/[0.05] px-5 py-2 text-xs text-rose-100" role="alert">{errorMessage(neteaseError)}</p> : null}
-    </article>
-    <LocalDifficultyDialog client={client} onClose={() => setDifficultyDialogOpen(false)} onFindSimilar={onFindSimilar} onOpen={(resourceId) => { setDifficultyDialogOpen(false); onOpen(resourceId); }} open={difficultyDialogOpen} set={set} />
+
+        {/* 与在线卡片一致：常驻核心信息，悬停后在卡片内部补充完整指标与难度。 */}
+        <div aria-hidden="true" className="opp-beatmap-card__details pointer-events-none absolute inset-x-0 bottom-0 top-[40%] z-20 translate-y-2.5 overflow-y-auto overscroll-contain border-t border-white/[.08] bg-[linear-gradient(180deg,rgba(21,25,31,.97),rgba(13,16,21,.99))] p-[14px_16px] opacity-0 [transition:opacity_var(--motion-base)_ease,transform_var(--motion-base)_cubic-bezier(.2,.8,.2,1)] group-hover:pointer-events-auto group-hover:translate-y-0 group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:translate-y-0 group-focus-within:opacity-100 motion-reduce:transition-none">
+          <div className="opp-beatmap-card__metrics grid grid-cols-6 gap-x-2">
+            {[{ label: "星级", value: starRange }, { label: "BPM", value: set.bpm.toFixed(0) }, { label: "长度", value: formatDuration(set.length_ms) }, { label: "物件", value: fullNumber(set.object_count) }, { label: "Peak NPS", value: peakNps.toFixed(1) }, { label: "难度", value: String(difficulties.length) }].map((metric) => <div className="min-w-0" key={metric.label}><p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-slate-500">{metric.label}</p><p className="mt-0.5 truncate text-xs font-semibold text-slate-100">{metric.value}</p></div>)}
+          </div>
+          <div className="opp-beatmap-card__detail-difficulties mt-3 flex flex-wrap content-start gap-1.5">
+            {difficulties.map((difficulty) => <span className="inline-flex min-w-0 items-center gap-1 rounded-md border border-white/10 bg-black/20 pr-2" key={difficulty.resource.resource_id}><DifficultyIcon className="border-0 bg-transparent px-1.5 py-1" mode={difficulty.ruleset} stars={difficulty.stars} /><span className="max-w-28 truncate text-[11px] text-slate-200">{difficulty.difficulty_name}</span></span>)}
+          </div>
+        </div>
+
+        {statusMessage ? <p aria-live="polite" className={`pointer-events-none absolute inset-x-3 bottom-3 z-40 truncate rounded-lg border px-3 py-1.5 text-[11px] backdrop-blur-md ${neteaseError ? "border-rose-300/25 bg-rose-950/85 text-rose-100" : "border-white/15 bg-black/75 text-slate-200"}`} role={neteaseError ? "alert" : undefined} title={statusMessage}>{statusMessage}</p> : null}
+      </Card>
+      <LocalDifficultyDialog client={client} onClose={() => setDifficultyDialogOpen(false)} onFindSimilar={onFindSimilar} onOpen={(resourceId) => { setDifficultyDialogOpen(false); onOpen(resourceId); }} open={difficultyDialogOpen} set={set} />
     </>
   );
 }
@@ -446,7 +416,7 @@ export function BeatmapSetPanel({
   };
 
   return (
-    <div>
+    <div className="opp-online-results opp-local-results">
       <Card className="mb-4 overflow-hidden">
         <div className="flex items-center gap-3 p-3">
           <div className="min-w-64 flex-1">
@@ -583,16 +553,16 @@ export function BeatmapSetPanel({
       </Card>
 
       {sets.isLoading ? (
-        <div className="space-y-3">
+        <div className="opp-online-results-grid opp-local-results-grid">
           {Array.from({ length: 5 }, (_, index) => (
-            <Skeleton className="h-52 rounded-[22px]" key={index} />
+            <Skeleton className="opp-beatmap-card-skeleton rounded-xl" key={index} />
           ))}
         </div>
       ) : sets.error ? (
         <ErrorPanel error={sets.error} onRetry={() => sets.refetch()} />
       ) : sets.data?.items.length ? (
         <>
-          <div className="space-y-3">
+          <div className="opp-online-results-grid opp-local-results-grid">
             {sets.data.items.map((set) => (
               <BeatmapSetCard
                 client={client}

--- a/src/features/online-beatmaps/OnlineBeatmapFilters.test.tsx
+++ b/src/features/online-beatmaps/OnlineBeatmapFilters.test.tsx
@@ -54,6 +54,12 @@ describe("OnlineBeatmapFilters", () => {
     expect(screen.getByRole("button", { name: "有视频" })).toBeVisible();
     expect(screen.getAllByRole("group", { name: "常规筛选" })).toHaveLength(1);
     expect(screen.getAllByRole("group", { name: "不良内容筛选" })).toHaveLength(1);
+    const advancedDiscrete = container.querySelector("[data-online-advanced-discrete]");
+    expect(advancedDiscrete).toHaveClass("border-b");
+    expect(advancedDiscrete).not.toHaveClass("border-t", "border-y");
+    expect(screen.getByRole("group", { name: "常规筛选" }).parentElement).toHaveClass("min-h-10", "py-1");
+    expect(screen.getByLabelText("艺术家")).toHaveClass("opp-filter-compact-input");
+    expect(screen.getAllByPlaceholderText("最小")[0]).toHaveClass("opp-filter-compact-input");
 
     await user.click(screen.getByRole("button", { name: "社区喜爱 (Loved)" }));
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ status: "loved" }));

--- a/src/features/online-beatmaps/OnlineBeatmapFilters.tsx
+++ b/src/features/online-beatmaps/OnlineBeatmapFilters.tsx
@@ -4,16 +4,17 @@ import { Badge, Button, Card, InfoTip, Input } from "../../shared/components/ui"
 import type { OnlineBeatmapSearchQuery, Ruleset } from "../../shared/types/osu";
 import { SearchAutocomplete, type SearchSuggestion } from "../../shared/components/SearchAutocomplete";
 import { activeFilterCount, genreOptions, languageOptions, parseOptionalNumber, statusOptions } from "./filters";
+import "./onlineBeatmapFilters.css";
 
-const inputClass = "w-full px-3 py-2.5 text-sm placeholder:text-slate-600";
+const inputClass = "opp-filter-compact-input w-full placeholder:text-slate-600";
 
 function Field({ label, children }: { label: string; children: ReactNode }) {
-  return <label className="block"><span className="mb-2 block text-sm font-medium text-slate-400">{label}</span>{children}</label>;
+  return <label className="block"><span className="mb-1 block text-xs font-medium text-slate-400">{label}</span>{children}</label>;
 }
 
 function FilterRow({ label, children }: { label: string; children: ReactNode }) {
   return (
-    <div className="grid min-h-12 items-center gap-1.5 border-t border-[var(--line-subtle)] py-1.5 first:border-t-0 sm:grid-cols-[clamp(4.75rem,calc(3.25rem+2vw),6.25rem)_minmax(0,1fr)] sm:gap-3">
+    <div className="grid min-h-10 items-center gap-1 border-t border-[var(--line-subtle)] py-1 first:border-t-0 sm:grid-cols-[clamp(4.75rem,calc(3.25rem+2vw),6.25rem)_minmax(0,1fr)] sm:gap-2.5">
       <div className="whitespace-nowrap text-[clamp(11px,calc(8px+0.3vw),14px)] font-semibold leading-5 text-slate-500">{label}</div>
       <div aria-label={`${label}筛选`} className="flex min-w-0 flex-nowrap items-center gap-1.5 overflow-x-auto overscroll-x-contain [scrollbar-color:var(--line-strong)_transparent] [scrollbar-width:thin]" role="group">{children}</div>
     </div>
@@ -24,7 +25,7 @@ function TextOption({ active, children, onClick }: { active: boolean; children: 
   return (
     <button
       aria-pressed={active}
-      className={`shrink-0 whitespace-nowrap rounded-md px-1.5 py-1 text-left transition-colors ${active ? "bg-[var(--theme-primary-muted)] font-semibold text-[var(--theme-primary-light)]" : "font-normal text-slate-500 hover:bg-[var(--surface-interactive)] hover:text-slate-200"}`}
+      className={`shrink-0 whitespace-nowrap rounded-md px-1.5 py-0.5 text-left transition-colors ${active ? "bg-[var(--theme-primary-muted)] font-semibold text-[var(--theme-primary-light)]" : "font-normal text-slate-500 hover:bg-[var(--surface-interactive)] hover:text-slate-200"}`}
       onClick={onClick}
       type="button"
     >
@@ -35,7 +36,7 @@ function TextOption({ active, children, onClick }: { active: boolean; children: 
 }
 
 function Range({ label, min, max, onMin, onMax }: { label: string; min: number | null; max: number | null; onMin: (value: number | null) => void; onMax: (value: number | null) => void }) {
-  return <Field label={label}><div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2"><Input className={inputClass} inputMode="decimal" onChange={(event) => onMin(parseOptionalNumber(event.target.value))} placeholder="最小" type="number" value={min ?? ""} /><span className="text-slate-600">至</span><Input className={inputClass} inputMode="decimal" onChange={(event) => onMax(parseOptionalNumber(event.target.value))} placeholder="最大" type="number" value={max ?? ""} /></div></Field>;
+  return <Field label={label}><div className="grid grid-cols-[1fr_auto_1fr] items-center gap-1.5"><Input className={inputClass} inputMode="decimal" onChange={(event) => onMin(parseOptionalNumber(event.target.value))} placeholder="最小" type="number" value={min ?? ""} /><span className="text-xs text-slate-600">至</span><Input className={inputClass} inputMode="decimal" onChange={(event) => onMax(parseOptionalNumber(event.target.value))} placeholder="最大" type="number" value={max ?? ""} /></div></Field>;
 }
 
 const rulesetOptions: ReadonlyArray<{ value: Ruleset | null; label: string }> = [
@@ -78,7 +79,7 @@ export function OnlineBeatmapFilters({ query, loading, onChange, onReset, onSubm
         </div>
 
         <div className="px-5 pb-1">
-          <div className="relative py-4" data-page-guide-online-search="true"><SearchAutocomplete ariaLabel="搜索在线谱面" className="w-full" inputClassName={`opp-input ${inputClass} py-3 pl-11 pr-10 text-[clamp(14px,calc(10px+0.3vw),16px)]`} onChange={(value) => patch({ query: value })} placeholder="输入关键字..." suggestions={suggestions} value={query.query} /><span className="absolute right-3 top-1/2 z-20 -translate-y-1/2"><InfoTip text="自动补全只基于当前已加载的搜索结果。输入后点击“应用筛选”进行完整的在线搜索。" /></span></div>
+          <div className="relative py-3" data-page-guide-online-search="true"><SearchAutocomplete ariaLabel="搜索在线谱面" className="w-full" inputClassName={`opp-input ${inputClass} opp-filter-search-input`} onChange={(value) => patch({ query: value })} placeholder="输入关键字..." suggestions={suggestions} value={query.query} /><span className="absolute right-3 top-1/2 z-20 -translate-y-1/2"><InfoTip text="自动补全只基于当前已加载的搜索结果。输入后点击“应用筛选”进行完整的在线搜索。" /></span></div>
 
           {/* 首屏只保留最常用条件，其余能力继续复用原有查询字段。 */}
           <div className="border-y border-[var(--line-subtle)]" data-page-guide-online-core-filters="true">
@@ -90,14 +91,15 @@ export function OnlineBeatmapFilters({ query, loading, onChange, onReset, onSubm
 
           <div data-page-guide-online-advanced="true">
             {!advancedOpen ? (
-              <button aria-expanded="false" className="flex w-full items-center justify-center gap-2 py-3.5 text-slate-500 transition hover:text-white" onClick={() => setAdvancedOpen(true)} type="button">
+              <button aria-expanded="false" className="flex w-full items-center justify-center gap-2 py-2.5 text-slate-500 transition hover:text-white" onClick={() => setAdvancedOpen(true)} type="button">
                 <ChevronDown className="size-4" />
                 <span className="text-[clamp(12px,calc(9px+0.2vw),13px)] font-semibold">更多筛选{count ? ` · ${count}` : ""}</span>
               </button>
             ) : (
               <>
-                <div className="space-y-5 pt-4">
-                  <div className="border-y border-[var(--line-subtle)]">
+                <div className="space-y-3">
+                  {/* 核心筛选的下边框直接作为高级筛选起始线，避免边界重复。 */}
+                  <div className="border-b border-[var(--line-subtle)]" data-online-advanced-discrete="true">
                     <FilterRow label="流派">{genreOptions.map((option) => <TextOption active={query.genre === option.value} key={option.value ?? "all"} onClick={() => select({ genre: option.value })}>{option.value === null ? "全部" : option.label}</TextOption>)}</FilterRow>
                     <FilterRow label="语言">{languageOptions.map((option) => <TextOption active={query.language === option.value} key={option.value ?? "all"} onClick={() => select({ language: option.value })}>{option.value === null ? "全部" : option.label}</TextOption>)}</FilterRow>
                     {query.ruleset === "mania" ? <FilterRow label="键数"><TextOption active={query.keys_min === null && query.keys_max === null} onClick={() => select({ keys_min: null, keys_max: null })}>全部</TextOption>{maniaKeyOptions.map((keys) => <TextOption active={query.keys_min === keys && query.keys_max === keys} key={keys} onClick={() => select({ keys_min: keys, keys_max: keys })}>{keys}K</TextOption>)}</FilterRow> : null}
@@ -105,13 +107,13 @@ export function OnlineBeatmapFilters({ query, loading, onChange, onReset, onSubm
                     <FilterRow label="成绩">{gradeOptions.map(([value, label]) => <TextOption active={query.grade === value} key={value || "all"} onClick={() => select({ grade: value })}>{label}</TextOption>)}</FilterRow>
                     <FilterRow label="玩过">{playedOptions.map(([value, label]) => <TextOption active={query.played === value} key={value || "all"} onClick={() => select({ played: value })}>{label}</TextOption>)}</FilterRow>
                   </div>
-                  <div className="space-y-4 border-b border-[var(--line-subtle)] pb-5">
-                    <div className="grid gap-4 md:grid-cols-2"><Field label="艺术家"><Input className={inputClass} onChange={(event) => patch({ artist: event.target.value })} value={query.artist} /></Field><Field label="标题"><Input className={inputClass} onChange={(event) => patch({ title: event.target.value })} value={query.title} /></Field><Field label="谱师"><Input className={inputClass} onChange={(event) => patch({ mapper: event.target.value })} value={query.mapper} /></Field><Field label="来源"><Input className={inputClass} onChange={(event) => patch({ source: event.target.value })} value={query.source} /></Field><Field label="标签"><Input className={inputClass} onChange={(event) => patch({ tags: event.target.value })} placeholder="逗号分隔" value={query.tags} /></Field></div>
-                    <div className="grid gap-4 md:grid-cols-2"><Field label="上架日期范围"><div className="grid grid-cols-2 gap-2"><Input className={inputClass} onChange={(event) => patch({ ranked_from: event.target.value })} type="date" value={query.ranked_from} /><Input className={inputClass} onChange={(event) => patch({ ranked_to: event.target.value })} type="date" value={query.ranked_to} /></div></Field><Field label="提交日期范围"><div className="grid grid-cols-2 gap-2"><Input className={inputClass} onChange={(event) => patch({ submitted_from: event.target.value })} type="date" value={query.submitted_from} /><Input className={inputClass} onChange={(event) => patch({ submitted_to: event.target.value })} type="date" value={query.submitted_to} /></div></Field></div>
+                  <div className="space-y-3 border-b border-[var(--line-subtle)] pb-3">
+                    <div className="grid gap-3 md:grid-cols-2"><Field label="艺术家"><Input className={inputClass} onChange={(event) => patch({ artist: event.target.value })} value={query.artist} /></Field><Field label="标题"><Input className={inputClass} onChange={(event) => patch({ title: event.target.value })} value={query.title} /></Field><Field label="谱师"><Input className={inputClass} onChange={(event) => patch({ mapper: event.target.value })} value={query.mapper} /></Field><Field label="来源"><Input className={inputClass} onChange={(event) => patch({ source: event.target.value })} value={query.source} /></Field><Field label="标签"><Input className={inputClass} onChange={(event) => patch({ tags: event.target.value })} placeholder="逗号分隔" value={query.tags} /></Field></div>
+                    <div className="grid gap-3 md:grid-cols-2"><Field label="上架日期范围"><div className="grid grid-cols-2 gap-1.5"><Input className={inputClass} onChange={(event) => patch({ ranked_from: event.target.value })} type="date" value={query.ranked_from} /><Input className={inputClass} onChange={(event) => patch({ ranked_to: event.target.value })} type="date" value={query.ranked_to} /></div></Field><Field label="提交日期范围"><div className="grid grid-cols-2 gap-1.5"><Input className={inputClass} onChange={(event) => patch({ submitted_from: event.target.value })} type="date" value={query.submitted_from} /><Input className={inputClass} onChange={(event) => patch({ submitted_to: event.target.value })} type="date" value={query.submitted_to} /></div></Field></div>
                   </div>
-                  <div className="grid gap-4 pb-1 md:grid-cols-2"><Range label="星数" max={query.stars_max} min={query.stars_min} onMax={(stars_max) => patch({ stars_max })} onMin={(stars_min) => patch({ stars_min })} /><Range label="BPM" max={query.bpm_max} min={query.bpm_min} onMax={(bpm_max) => patch({ bpm_max })} onMin={(bpm_min) => patch({ bpm_min })} /><Range label="长度（秒）" max={query.length_max} min={query.length_min} onMax={(length_max) => patch({ length_max })} onMin={(length_min) => patch({ length_min })} /><Range label="收藏量" max={query.favourites_max} min={query.favourites_min} onMax={(favourites_max) => patch({ favourites_max })} onMin={(favourites_min) => patch({ favourites_min })} /><Range label="AR" max={query.ar_max} min={query.ar_min} onMax={(ar_max) => patch({ ar_max })} onMin={(ar_min) => patch({ ar_min })} /><Range label="CS" max={query.cs_max} min={query.cs_min} onMax={(cs_max) => patch({ cs_max })} onMin={(cs_min) => patch({ cs_min })} /><Range label="OD" max={query.od_max} min={query.od_min} onMax={(od_max) => patch({ od_max })} onMin={(od_min) => patch({ od_min })} /><Range label="HP" max={query.hp_max} min={query.hp_min} onMax={(hp_max) => patch({ hp_max })} onMin={(hp_min) => patch({ hp_min })} /></div>
+                  <div className="grid gap-3 pb-1 md:grid-cols-2"><Range label="星数" max={query.stars_max} min={query.stars_min} onMax={(stars_max) => patch({ stars_max })} onMin={(stars_min) => patch({ stars_min })} /><Range label="BPM" max={query.bpm_max} min={query.bpm_min} onMax={(bpm_max) => patch({ bpm_max })} onMin={(bpm_min) => patch({ bpm_min })} /><Range label="长度（秒）" max={query.length_max} min={query.length_min} onMax={(length_max) => patch({ length_max })} onMin={(length_min) => patch({ length_min })} /><Range label="收藏量" max={query.favourites_max} min={query.favourites_min} onMax={(favourites_max) => patch({ favourites_max })} onMin={(favourites_min) => patch({ favourites_min })} /><Range label="AR" max={query.ar_max} min={query.ar_min} onMax={(ar_max) => patch({ ar_max })} onMin={(ar_min) => patch({ ar_min })} /><Range label="CS" max={query.cs_max} min={query.cs_min} onMax={(cs_max) => patch({ cs_max })} onMin={(cs_min) => patch({ cs_min })} /><Range label="OD" max={query.od_max} min={query.od_min} onMax={(od_max) => patch({ od_max })} onMin={(od_min) => patch({ od_min })} /><Range label="HP" max={query.hp_max} min={query.hp_min} onMax={(hp_max) => patch({ hp_max })} onMin={(hp_min) => patch({ hp_min })} /></div>
                 </div>
-                <button aria-expanded="true" className="mt-4 flex w-full items-center justify-center gap-2 border-t border-[var(--line-subtle)] py-3.5 text-slate-500 transition hover:text-white" onClick={() => setAdvancedOpen(false)} type="button">
+                <button aria-expanded="true" className="mt-3 flex w-full items-center justify-center gap-2 border-t border-[var(--line-subtle)] py-2.5 text-slate-500 transition hover:text-white" onClick={() => setAdvancedOpen(false)} type="button">
                   <ChevronUp className="size-4" />
                   <span className="text-[clamp(12px,calc(9px+0.2vw),13px)] font-semibold">收起筛选</span>
                 </button>

--- a/src/features/online-beatmaps/onlineBeatmapFilters.css
+++ b/src/features/online-beatmaps/onlineBeatmapFilters.css
@@ -1,0 +1,12 @@
+/* 只压缩在线筛选的高级输入区，避免改变全局 Input 和其他页面的控件尺寸。 */
+.opp-beatmap-filter .opp-filter-compact-input {
+  padding: 0.375rem 0.625rem;
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+}
+
+/* 顶部主搜索保留更高的信息层级，同时仍比旧布局紧凑。 */
+.opp-beatmap-filter .opp-filter-search-input {
+  padding: 0.625rem 2.5rem 0.625rem 2.75rem;
+  font-size: clamp(0.875rem, calc(0.625rem + 0.3vw), 1rem);
+}


### PR DESCRIPTION
## 改动内容

- `src/features/online-beatmaps/OnlineBeatmapFilters.tsx`：移除核心筛选与高级离散筛选交界处的重复边框，收紧筛选行、搜索区、文字/日期字段和数值范围的纵向间距。
- `src/features/online-beatmaps/onlineBeatmapFilters.css`：为在线筛选输入框增加局部尺寸规则，以组件作用域覆盖全局 `.opp-input`，不使用 `!important`，不影响其他页面。
- `src/features/online-beatmaps/OnlineBeatmapFilters.test.tsx`：补充单边界、紧凑行高和局部输入样式的回归断言。
- `src/features/local-analysis/BeatmapSetPanel.tsx`：将本地谱面集从单列大面板改为与在线谱面一致的响应式双列媒体卡片，统一卡片比例、主题蒙版、难度摘要和悬浮详情；保留打开文件/导出、官网、网易云、难度详情、相似谱面、收藏夹、Trainer 与预览入口。
- `src/features/local-analysis/BeatmapSetPanel.test.tsx`：新增本地谱面网格、媒体卡片、难度顺序和详情弹窗测试。

## 目的

- 修复“不良内容”与“流派”之间出现两条横线的问题。
- 降低在线筛选栏的无效高度，尤其是高级文字、日期和范围输入区。
- 让本地铺面与在线铺面使用一致的结果浏览方式，减少同类页面之间的视觉和操作差异。

## 验证

- `pnpm lint`
- `pnpm test`（38 个测试文件、106 项测试通过）
- `pnpm build`
- Playwright 真实浏览器检查：1440×900 下展开筛选仅保留单条交界线，紧凑输入样式生效。