### PR TITLE
修复铺面卡片难度摘要拥挤与计数显示

### DIFF
--- a/src/features/collections/CollectionsPage.tsx
+++ b/src/features/collections/CollectionsPage.tsx
@@ -1,9 +1,11 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { open } from "@tauri-apps/plugin-dialog";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useBeforeUnload, useNavigate } from "react-router-dom";
 import {
+  ChevronDown,
+  ChevronUp,
   Download,
   FileInput,
   FileOutput,
@@ -92,10 +94,12 @@ function ImportPreviewDialog({
   );
 }
 
-function FolderCard({ folder, onChanged, onDownload }: { folder: CollectionFolder; onChanged: (folderId: string, entryId?: string) => Promise<void>; onDownload: (folderId: string) => Promise<void> }) {
+export function FolderCard({ folder, onChanged, onDownload }: { folder: CollectionFolder; onChanged: (folderId: string, entryId?: string) => Promise<void>; onDownload: (folderId: string) => Promise<void> }) {
   const [exported, setExported] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(true);
+  const contentId = useId();
 
   const remove = async (entryId?: string) => {
     setBusy(true);
@@ -124,7 +128,7 @@ function FolderCard({ folder, onChanged, onDownload }: { folder: CollectionFolde
 
   return (
     <Card className="collection-folder opp-collection-folder overflow-hidden">
-      <div className="flex items-start justify-between gap-4 border-b border-white/[0.07] p-5">
+      <div className={`flex items-center justify-between gap-4 transition-[padding] duration-[var(--motion-fast)] ${expanded ? "border-b border-white/[0.07] p-5" : "px-5 py-3.5"}`}>
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
             <h2 className="truncate text-base font-semibold text-white">{folder.name}</h2>
@@ -134,27 +138,43 @@ function FolderCard({ folder, onChanged, onDownload }: { folder: CollectionFolde
           <p className="mt-1 text-xs text-slate-500">{folder.creator || "未署名"} · {folder.entries.length} 个难度{missingSets ? ` · 缺失 ${missingSets} 项` : ""}</p>
         </div>
         <div className="flex gap-1">
+          <Button
+            aria-controls={contentId}
+            aria-expanded={expanded}
+            aria-label={`${expanded ? "收起" : "展开"}收藏夹 ${folder.name}`}
+            onClick={() => setExpanded((value) => !value)}
+            size="icon"
+            title={expanded ? "收起收藏夹" : "展开收藏夹"}
+            variant="ghost"
+          >
+            {expanded ? <ChevronUp className="size-4" /> : <ChevronDown className="size-4" />}
+          </Button>
           <Button disabled={busy} onClick={() => void exportShare()} size="icon" title="导出分享码" variant="ghost"><FileOutput className="size-4" /></Button>
           <Button disabled={busy || folder.read_only} onClick={() => void download()} size="icon" title={missingSets ? `解析并补齐 ${missingSets} 个缺失项` : "检查是否有缺失谱面"} variant="ghost"><Download className="size-4" /></Button>
           <Button disabled={busy || folder.read_only} onClick={() => void remove()} size="icon" title="删除收藏夹" variant="ghost"><Trash2 className="size-4" /></Button>
         </div>
       </div>
-      <div className="max-h-[min(34rem,60vh)] overflow-y-auto p-3.5">
-        {folder.entries.length ? (
-          <div className="opp-map-grid">
-            {/* 列数依据收藏夹内容区宽度变化，避免窗口断点与卡片实际空间脱节。 */}
-            {folder.entries.map((entry) => (
-              <MapCard
-                busy={busy}
-                entry={entry}
-                key={entry.id}
-                onRemove={() => void remove(entry.id)}
-                readOnly={folder.read_only}
-              />
-            ))}
+      {expanded ? (
+        // 折叠时不渲染卡片网格，既缩短页面，也避免隐藏内容继续占用布局和交互焦点。
+        <div id={contentId}>
+          <div className="max-h-[min(34rem,60vh)] overflow-y-auto p-3.5">
+            {folder.entries.length ? (
+              <div className="opp-map-grid">
+                {/* 列数依据收藏夹内容区宽度变化，避免窗口断点与卡片实际空间脱节。 */}
+                {folder.entries.map((entry) => (
+                  <MapCard
+                    busy={busy}
+                    entry={entry}
+                    key={entry.id}
+                    onRemove={() => void remove(entry.id)}
+                    readOnly={folder.read_only}
+                  />
+                ))}
+              </div>
+            ) : <p className="px-5 py-8 text-center text-sm text-slate-600">还没有谱面</p>}
           </div>
-        ) : <p className="px-5 py-8 text-center text-sm text-slate-600">还没有谱面</p>}
-      </div>
+        </div>
+      ) : null}
       {exported ? <div className="border-t border-white/[0.07] p-4"><p className="mb-2 text-xs text-emerald-200">分享码已复制。OPPC2 会紧凑保存在线谱面 ID。</p><textarea className="h-20 w-full rounded-lg border border-white/10 bg-black/20 p-2 font-mono text-[10px] text-slate-400" readOnly value={exported} /></div> : null}
       {error ? <p className="p-4 text-sm text-rose-200">{error}</p> : null}
     </Card>

--- a/src/features/collections/FolderCard.test.tsx
+++ b/src/features/collections/FolderCard.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CollectionFolder } from "../../shared/types/osu";
+import { FolderCard } from "./CollectionsPage";
+
+const folder: CollectionFolder = {
+  id: "folder-1",
+  name: "练习收藏",
+  creator: "Player",
+  created_at: "2026-08-23T00:00:00Z",
+  updated_at: "2026-08-23T00:00:00Z",
+  source: "stable",
+  read_only: false,
+  pending_write: false,
+  entries: [{
+    id: "entry-1",
+    beatmap_id: 123,
+    beatmapset_id: 456,
+    checksum: "checksum",
+    ruleset: "osu",
+    difficulty_name: "Insane",
+    title: "Local Song",
+    artist: "Local Artist",
+    creator: "Local Mapper",
+    resolved: true,
+  }],
+};
+
+describe("FolderCard", () => {
+  it("collapses to a compact header and expands its map grid again", async () => {
+    const user = userEvent.setup();
+    render(
+      <FolderCard
+        folder={folder}
+        onChanged={vi.fn()}
+        onDownload={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Local Song")).toBeInTheDocument();
+    const collapse = screen.getByRole("button", { name: "收起收藏夹 练习收藏" });
+    expect(collapse).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(collapse);
+    expect(screen.queryByText("Local Song")).not.toBeInTheDocument();
+    expect(screen.getByText("Player · 1 个难度")).toBeInTheDocument();
+
+    const expand = screen.getByRole("button", { name: "展开收藏夹 练习收藏" });
+    expect(expand).toHaveAttribute("aria-expanded", "false");
+    await user.click(expand);
+    expect(screen.getByText("Local Song")).toBeInTheDocument();
+  });
+});

--- a/src/features/local-analysis/BeatmapSetPanel.test.tsx
+++ b/src/features/local-analysis/BeatmapSetPanel.test.tsx
@@ -86,8 +86,11 @@ describe("BeatmapSetPanel", () => {
     expect(card.querySelector(".opp-beatmap-card__cover-overlay")).toBeInTheDocument();
     expect(card.querySelector(".opp-beatmap-card__details")).toBeInTheDocument();
 
-    const compactRatings = Array.from(card.querySelectorAll('.opp-beatmap-card__difficulty-list [title$=" stars"]'), (node) => node.textContent?.trim());
+    const compact = card.querySelector(".opp-difficulty-summary");
+    const compactRatings = Array.from(compact?.querySelectorAll('[title$=" stars"]') ?? [], (node) => node.textContent?.trim());
     expect(compactRatings).toEqual(["2.10", "5.40"]);
+    expect(compact).not.toHaveTextContent("Easy");
+    expect(card.querySelector(".opp-beatmap-card__detail-difficulties")).toHaveTextContent("Easy");
 
     await user.click(card);
     expect(screen.getByRole("dialog")).toBeVisible();

--- a/src/features/local-analysis/BeatmapSetPanel.tsx
+++ b/src/features/local-analysis/BeatmapSetPanel.tsx
@@ -37,6 +37,7 @@ import {
   Skeleton,
 } from "../../shared/components/ui";
 import { SearchAutocomplete } from "../../shared/components/SearchAutocomplete";
+import { CompactDifficultySummary } from "../../shared/components/CompactDifficultySummary";
 import { errorMessage, fullNumber, rulesetLabels } from "../../shared/lib/format";
 import { desktopApi } from "../../shared/lib/tauri";
 import { DifficultyIcon, ModeIcon } from "../online-beatmaps/BeatmapVisuals";
@@ -279,11 +280,14 @@ function BeatmapSetCard({
               <Badge tone="cyan">{difficulties.length} 个难度</Badge>
               {set.grouping_inferred ? <Badge tone="warning">推断分组</Badge> : null}
             </div>
-            <div className="opp-beatmap-card__difficulty-list flex min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap">
-              <span className="mr-1 shrink-0 text-[11px] font-semibold text-slate-400">难度</span>
-              {difficulties.slice(0, 5).map((difficulty) => <button className="inline-flex min-w-0 items-center gap-1.5 outline-none hover:brightness-110" key={difficulty.resource.resource_id} onClick={(event) => { event.stopPropagation(); onOpen(difficulty.resource.resource_id); }} type="button"><DifficultyIcon className="px-1.5 py-0.5" mode={difficulty.ruleset} stars={difficulty.stars} /><span className="opp-beatmap-card__difficulty-name max-w-24 truncate text-[11px] text-slate-200">{difficulty.difficulty_name}</span></button>)}
-              {difficulties.length > 5 ? <span className="text-[11px] font-medium text-slate-400">+{difficulties.length - 5}</span> : null}
-            </div>
+            <CompactDifficultySummary
+              items={difficulties.map((difficulty) => ({
+                id: difficulty.resource.resource_id,
+                mode: difficulty.ruleset,
+                onClick: () => onOpen(difficulty.resource.resource_id),
+                stars: difficulty.stars,
+              }))}
+            />
           </div>
         </div>
 
@@ -293,7 +297,7 @@ function BeatmapSetCard({
             {[{ label: "星级", value: starRange }, { label: "BPM", value: set.bpm.toFixed(0) }, { label: "长度", value: formatDuration(set.length_ms) }, { label: "物件", value: fullNumber(set.object_count) }, { label: "Peak NPS", value: peakNps.toFixed(1) }, { label: "难度", value: String(difficulties.length) }].map((metric) => <div className="min-w-0" key={metric.label}><p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-slate-500">{metric.label}</p><p className="mt-0.5 truncate text-xs font-semibold text-slate-100">{metric.value}</p></div>)}
           </div>
           <div className="opp-beatmap-card__detail-difficulties mt-3 flex flex-wrap content-start gap-1.5">
-            {difficulties.map((difficulty) => <span className="inline-flex min-w-0 items-center gap-1 rounded-md border border-white/10 bg-black/20 pr-2" key={difficulty.resource.resource_id}><DifficultyIcon className="border-0 bg-transparent px-1.5 py-1" mode={difficulty.ruleset} stars={difficulty.stars} /><span className="max-w-28 truncate text-[11px] text-slate-200">{difficulty.difficulty_name}</span></span>)}
+            {difficulties.map((difficulty) => <span className="inline-flex max-w-full items-center gap-1 rounded-md border border-white/10 bg-black/20 pr-2" key={difficulty.resource.resource_id}><DifficultyIcon className="border-0 bg-transparent px-1.5 py-1" mode={difficulty.ruleset} stars={difficulty.stars} /><span className="break-all text-[11px] text-slate-200">{difficulty.difficulty_name}</span></span>)}
           </div>
         </div>
 

--- a/src/features/local-analysis/LocalAnalysisPage.tsx
+++ b/src/features/local-analysis/LocalAnalysisPage.tsx
@@ -162,7 +162,7 @@ function SourceBar({
             variant="primary"
           >
             <RefreshCw className="size-3.5" />
-            {summary ? "刷新" : "扫描"}
+            {summary ? "增量刷新" : "扫描"}
           </Button>
         )}
         <Button

--- a/src/features/online-beatmaps/BeatmapsetCard.test.tsx
+++ b/src/features/online-beatmaps/BeatmapsetCard.test.tsx
@@ -86,7 +86,7 @@ describe("BeatmapsetCard", () => {
     expect(onOpen).toHaveBeenCalledOnce();
   });
 
-  it("sorts every difficulty by stars and keeps hover details scrollable", () => {
+  it("sorts every difficulty and keeps compact badges separate from the remaining count", () => {
     const difficulties = [
       { id: 701, difficulty_rating: 7.07, version: "Extra" },
       { id: 593, difficulty_rating: 5.93, version: "Another" },
@@ -112,13 +112,19 @@ describe("BeatmapsetCard", () => {
       />,
     );
 
-    const compact = container.querySelector(".opp-beatmap-card__difficulty-list");
+    const compact = container.querySelector(".opp-difficulty-summary");
     const details = container.querySelector(".opp-beatmap-card__details");
     const detailDifficulties = container.querySelector(".opp-beatmap-card__detail-difficulties");
     const ratings = (root: Element | null) => Array.from(root?.querySelectorAll('[title$=" stars"]') ?? [], (node) => node.textContent?.trim());
 
     expect(ratings(compact)).toEqual(["2.49", "3.38", "4.67", "5.93", "7.07"]);
+    expect(compact?.querySelector(".opp-difficulty-summary__items")).toHaveClass("opp-difficulty-summary__items");
+    expect(compact?.querySelector(".opp-difficulty-summary__count--3")).toHaveTextContent("+3");
+    expect(compact?.querySelector(".opp-difficulty-summary__count--4")).toHaveTextContent("+2");
+    expect(compact?.querySelector(".opp-difficulty-summary__count--5")).toHaveTextContent("+1");
+    expect(compact).not.toHaveTextContent("Normal");
     expect(ratings(detailDifficulties)).toEqual(["2.49", "3.38", "4.67", "5.93", "7.07", "8.10"]);
+    expect(detailDifficulties).toHaveTextContent("Normal");
     expect(details).toHaveClass("overflow-y-auto", "overscroll-contain", "group-hover:pointer-events-auto");
   });
 });

--- a/src/features/online-beatmaps/BeatmapsetCard.tsx
+++ b/src/features/online-beatmaps/BeatmapsetCard.tsx
@@ -1,5 +1,6 @@
 import { Check, Download, Headphones, Heart, Info, ListPlus, Pause } from "lucide-react";
 import { Badge, Button, Card } from "../../shared/components/ui";
+import { CompactDifficultySummary } from "../../shared/components/CompactDifficultySummary";
 import { DifficultyIcon } from "../../shared/components/DifficultyIcon";
 import { APP_TIME_ZONE, fullNumber } from "../../shared/lib/format";
 import { cn } from "../../shared/lib/cn";
@@ -92,11 +93,13 @@ export function BeatmapsetCard({ beatmapset, downloading, playing, selected, onA
           {beatmapset.video ? <Badge>VIDEO</Badge> : null}
           {disabled ? <Badge tone="warning">禁止下载</Badge> : null}
         </div>
-        <div className="opp-beatmap-card__difficulty-list flex min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap">
-          <span className="mr-1 shrink-0 text-[11px] font-semibold text-slate-400">难度</span>
-          {beatmaps.slice(0, 5).map((beatmap) => <span className="inline-flex min-w-0 items-center gap-1.5" key={beatmap.id}><DifficultyIcon className="px-1.5 py-0.5" mode={beatmap.mode} stars={beatmap.difficulty_rating} /><span className="opp-beatmap-card__difficulty-name max-w-24 truncate text-[11px] text-slate-200">{beatmap.version}</span></span>)}
-          {beatmaps.length > 5 ? <span className="text-[11px] font-medium text-slate-400">+{beatmaps.length - 5}</span> : null}
-        </div>
+        <CompactDifficultySummary
+          items={beatmaps.map((beatmap) => ({
+            id: beatmap.id,
+            mode: beatmap.mode,
+            stars: beatmap.difficulty_rating,
+          }))}
+        />
       </div>
     </div>
 
@@ -106,7 +109,7 @@ export function BeatmapsetCard({ beatmapset, downloading, playing, selected, onA
         {[{ label: "星级", value: `${minStars.toFixed(2)}–${maxStars.toFixed(2)}★` }, { label: "BPM", value: String(Math.round(beatmapset.bpm ?? 0)) }, { label: "长度", value: durationLabel(longest) }, { label: "物件", value: fullNumber(objects) }, { label: "游玩", value: fullNumber(beatmapset.play_count ?? 0) }, { label: "上架", value: dateLabel(beatmapset.ranked_date) }].map((metric) => <div className="min-w-0" key={metric.label}><p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-slate-500">{metric.label}</p><p className="mt-0.5 truncate text-xs font-semibold text-slate-100">{metric.value}</p></div>)}
       </div>
       <div className="opp-beatmap-card__detail-difficulties mt-3 flex flex-wrap content-start gap-1.5">
-        {beatmaps.map((beatmap) => <span className="inline-flex min-w-0 items-center gap-1 rounded-md border border-white/10 bg-black/20 pr-2" key={beatmap.id}><DifficultyIcon className="border-0 bg-transparent px-1.5 py-1" mode={beatmap.mode} stars={beatmap.difficulty_rating} /><span className="max-w-28 truncate text-[11px] text-slate-200">{beatmap.version}</span></span>)}
+        {beatmaps.map((beatmap) => <span className="inline-flex max-w-full items-center gap-1 rounded-md border border-white/10 bg-black/20 pr-2" key={beatmap.id}><DifficultyIcon className="border-0 bg-transparent px-1.5 py-1" mode={beatmap.mode} stars={beatmap.difficulty_rating} /><span className="break-all text-[11px] text-slate-200">{beatmap.version}</span></span>)}
       </div>
     </div>
   </Card>;

--- a/src/shared/components/CompactDifficultySummary.tsx
+++ b/src/shared/components/CompactDifficultySummary.tsx
@@ -1,0 +1,74 @@
+import type { MouseEvent } from "react";
+import type { Ruleset } from "../types/osu";
+import { DifficultyIcon } from "./DifficultyIcon";
+
+export interface CompactDifficultySummaryItem {
+  id: number | string;
+  mode: Ruleset;
+  stars: number | null | undefined;
+  onClick?: () => void;
+}
+
+function DifficultyItem({ item }: { item: CompactDifficultySummaryItem }) {
+  const content = (
+    <DifficultyIcon
+      className="opp-difficulty-summary__rating px-1.5 py-0.5"
+      mode={item.mode}
+      stars={item.stars}
+    />
+  );
+
+  if (!item.onClick) {
+    return <span className="opp-difficulty-summary__item">{content}</span>;
+  }
+
+  return (
+    <button
+      className="opp-difficulty-summary__item outline-none hover:brightness-110 focus-visible:ring-2 focus-visible:ring-[var(--theme-primary-soft)]"
+      onClick={(event: MouseEvent<HTMLButtonElement>) => {
+        event.stopPropagation();
+        item.onClick?.();
+      }}
+      type="button"
+    >
+      {content}
+    </button>
+  );
+}
+
+function HiddenCount({ count, visibleAt }: { count: number; visibleAt: 3 | 4 | 5 }) {
+  if (count <= 0) return null;
+
+  return (
+    <span
+      aria-label={`还有 ${count} 个难度`}
+      className={`opp-difficulty-summary__count opp-difficulty-summary__count--${visibleAt}`}
+      title={`还有 ${count} 个难度`}
+    >
+      +{count}
+    </span>
+  );
+}
+
+export function CompactDifficultySummary({
+  items,
+}: {
+  items: CompactDifficultySummaryItem[];
+}) {
+  const visibleItems = items.slice(0, 5);
+
+  return (
+    // 紧凑摘要按卡片实际宽度切换可见数量，计数始终独占一列，避免徽标互相挤压。
+    <div className="opp-difficulty-summary">
+      <span className="opp-difficulty-summary__label">难度</span>
+      <div className="opp-difficulty-summary__items">
+        {visibleItems.map((item) => (
+          <DifficultyItem item={item} key={item.id} />
+        ))}
+      </div>
+      <HiddenCount count={items.length - 3} visibleAt={3} />
+      <HiddenCount count={items.length - 4} visibleAt={4} />
+      <HiddenCount count={items.length - 5} visibleAt={5} />
+    </div>
+  );
+}

--- a/src/shared/styles/beatmapCards.css
+++ b/src/shared/styles/beatmapCards.css
@@ -14,6 +14,95 @@
   container: map-card / inline-size;
 }
 
+/* 难度摘要保留独立计数列，徽标不参与压缩，窄卡片只减少显示数量。 */
+.opp-difficulty-summary {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  column-gap: 0.5rem;
+  white-space: nowrap;
+}
+
+.opp-difficulty-summary__label {
+  flex: none;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: rgb(148 163 184);
+}
+
+.opp-difficulty-summary__items {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.375rem;
+  overflow: hidden;
+}
+
+.opp-difficulty-summary__item {
+  display: inline-flex;
+  flex: 0 0 auto;
+  border-radius: 0.5rem;
+}
+
+.opp-difficulty-summary__item:nth-child(n + 4) {
+  display: none;
+}
+
+.opp-difficulty-summary__rating {
+  min-width: 3.25rem;
+  justify-content: center;
+}
+
+.opp-difficulty-summary__count {
+  display: none;
+  height: 1.5rem;
+  min-width: 1.875rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line-strong);
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--surface-interactive-hover) 72%, transparent);
+  padding: 0 0.375rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  color: rgb(203 213 225);
+}
+
+.opp-difficulty-summary__count--3 {
+  display: inline-flex;
+}
+
+@container beatmap-card (min-width: 25rem) {
+  .opp-difficulty-summary__item:nth-child(4) {
+    display: inline-flex;
+  }
+
+  .opp-difficulty-summary__count--3 {
+    display: none;
+  }
+
+  .opp-difficulty-summary__count--4 {
+    display: inline-flex;
+  }
+}
+
+@container beatmap-card (min-width: 31rem) {
+  .opp-difficulty-summary__item:nth-child(5) {
+    display: inline-flex;
+  }
+
+  .opp-difficulty-summary__count--4 {
+    display: none;
+  }
+
+  .opp-difficulty-summary__count--5 {
+    display: inline-flex;
+  }
+}
+
 :root[data-theme-mode="light"] .opp-media-card {
   --line-strong: rgba(15, 23, 42, 0.18);
   --surface-interactive-hover: rgba(15, 23, 42, 0.075);
@@ -148,10 +237,6 @@
   .opp-beatmap-card__badges {
     margin-bottom: 0.5rem;
     gap: 0.375rem;
-  }
-
-  .opp-beatmap-card__difficulty-name {
-    display: none;
   }
 
   .opp-beatmap-card__details {


### PR DESCRIPTION
## 改动内容

- `src/shared/components/CompactDifficultySummary.tsx`：新增在线铺面与本地铺面共用的紧凑难度摘要组件；难度徽标固定不收缩，剩余数量使用独立计数徽标。
- `src/shared/styles/beatmapCards.css`：基于卡片容器宽度自适应显示 3、4 或 5 个难度，始终为 `+N` 保留空间，避免徽标裁切和重叠。
- `src/features/online-beatmaps/BeatmapsetCard.tsx`、`src/features/local-analysis/BeatmapSetPanel.tsx`：统一接入共享摘要；外层不再显示可能被省略的难度名，完整名称改在可滚动的悬停详情中展示。
- `src/features/local-analysis/LocalAnalysisPage.tsx`：将已有索引后的“刷新”明确为“增量刷新”，与现有持久化索引和增量复用语义一致。
- `src/features/collections/CollectionsPage.tsx`：为每个本地收藏夹增加独立的展开/收起按钮；折叠后只保留紧凑标题栏和原有操作，隐藏卡片网格。
- `src/features/collections/FolderCard.test.tsx` 及两个卡片测试文件：补充收藏夹折叠、难度排序、响应式剩余计数、外层名称隐藏和详情完整名称的回归断言。

## 目的

- 修复窗口较窄时难度徽标互相挤压、局部重叠或被裁掉的问题。
- 让 `+N` 与难度徽标视觉分离，不再和最后一个难度重叠。
- 避免外层出现 `Sapuine...` 一类半截难度名；完整名称统一在悬停详情中查看。
- 允许单独折叠内容较多的本地收藏夹，缩短收藏夹页面高度，同时保留导出、补齐和删除入口。
- 明确本地铺面已有持久化缓存：启动只加载索引，普通刷新复用未变化条目，只有“强制重建”才全量重算；本次不改动后端缓存链路。

## 验证

- `pnpm lint`
- `pnpm test`（39 个测试文件、107 项测试通过）
- `pnpm build`
- Playwright 真实浏览器容器宽度检查：紧凑、中等、宽三档分别稳定显示 3/4/5 个难度，独立 `+N` 无裁切和重叠。