### PR TITLE
修复难度剩余计数在浅色主题下对比度不足

### DIFF
--- a/src/shared/styles/beatmapCards.css
+++ b/src/shared/styles/beatmapCards.css
@@ -61,14 +61,14 @@
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--line-strong);
+  border: 1px solid rgba(248, 250, 252, 0.34);
   border-radius: 0.5rem;
-  background: color-mix(in srgb, var(--surface-interactive-hover) 72%, transparent);
+  background: rgba(15, 23, 42, 0.78);
   padding: 0 0.375rem;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 0.6875rem;
   font-weight: 700;
-  color: rgb(203 213 225);
+  color: #f8fafc;
 }
 
 .opp-difficulty-summary__count--3 {
@@ -109,6 +109,13 @@
   color: #172033;
   background-color: #f8fafc;
   box-shadow: 0 9px 24px rgba(24, 32, 54, 0.11);
+}
+
+/* 计数徽标与难度星级保持相同的主题对比：深色用白字，浅色用近黑字。 */
+:root[data-theme-mode="light"] .opp-media-card .opp-difficulty-summary__count {
+  border-color: rgba(15, 23, 42, 0.32);
+  background: rgba(255, 255, 255, 0.9);
+  color: #111827;
 }
 
 :root[data-theme-mode="light"] .opp-media-card [class*="text-white"],


### PR DESCRIPTION
## 改动内容

- `src/shared/styles/beatmapCards.css`：移除 `+N` 计数徽标写死的灰色文字。
- 深色主题使用近白文字、深色底和浅色边框。
- 浅色主题使用近黑文字、白色底和深色边框，与难度星级徽标保持一致的主题对比。

## 目的

修复 `+N` 在浅色主题中颜色过灰、辨识度不足的问题，同时确保深色主题仍然清晰。

## 验证

- `pnpm lint`
- `pnpm build`
- Playwright 真实浏览器计算样式：
  - 深色文字：`rgb(248, 250, 252)`
  - 浅色文字：`rgb(17, 24, 39)`
  - 两套主题下均检查了背景与边框显示。