### PR TITLE
修复本地皮肤 Combo Color 预览

### DIFF
--- a/src-tauri/src/local_analysis/parser.rs
+++ b/src-tauri/src/local_analysis/parser.rs
@@ -478,6 +478,41 @@ fn parse_color(value: &str) -> Option<Vec<u8>> {
     (components.len() == 3 || components.len() == 4).then_some(components)
 }
 
+const DEFAULT_SKIN_COMBO_COLORS: [[u8; 3]; 4] = [
+    [255, 192, 0],
+    [0, 202, 0],
+    [18, 124, 255],
+    [242, 24, 57],
+];
+
+/// 仅提取 `[Colours]` 中有效的 Combo 色；未配置时使用 osu! 经典默认色。
+fn skin_combo_colors(sections: &[SkinConfigSection]) -> Vec<Vec<u8>> {
+    let colors = sections
+        .iter()
+        .filter(|section| section.name.eq_ignore_ascii_case("Colours"))
+        .flat_map(|section| &section.entries)
+        .filter(|entry| {
+            entry
+                .key
+                .to_ascii_lowercase()
+                .strip_prefix("combo")
+                .and_then(|index| index.parse::<u8>().ok())
+                .is_some_and(|index| (1..=8).contains(&index))
+        })
+        .filter_map(|entry| entry.color.as_ref().map(|color| color[..3].to_vec()))
+        .take(8)
+        .collect::<Vec<_>>();
+
+    if colors.is_empty() {
+        DEFAULT_SKIN_COMBO_COLORS
+            .iter()
+            .map(|color| color.to_vec())
+            .collect()
+    } else {
+        colors
+    }
+}
+
 /// 解析 `skin.ini` 的分节键值对；重复键会按原始顺序保留。
 pub fn parse_skin_config(text: &str) -> Vec<SkinConfigSection> {
     let mut sections = Vec::<SkinConfigSection>::new();
@@ -607,12 +642,7 @@ pub fn parse_skin(
         resource_count: inventory.as_ref().map(|value| value.file_count),
         total_bytes: inventory.as_ref().map(|value| value.total_bytes),
         modified_at,
-        accent_colors: sections
-            .iter()
-            .flat_map(|section| &section.entries)
-            .filter_map(|entry| entry.color.clone())
-            .take(8)
-            .collect(),
+        accent_colors: skin_combo_colors(&sections),
     };
 
     Ok(LocalSkinDetail {
@@ -704,6 +734,33 @@ SliderTickRate:1
             parse_skin_config("[General]\nName: First\nName: Second\n[Colours]\nCombo1: 1, 2, 3\n");
         assert_eq!(parsed[0].entries.len(), 2);
         assert_eq!(parsed[1].entries[0].color, Some(vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn skin_combo_colors_only_uses_combo_entries_in_file_order() {
+        let parsed = parse_skin_config(
+            "[General]\nInputOverlayText: 1, 2, 3\n[Colours]\nMenuGlow: 4, 5, 6\nCombo3: 18, 124, 255\nCombo1: 255, 192, 0, 100\nCombo9: 9, 9, 9\n",
+        );
+
+        assert_eq!(
+            skin_combo_colors(&parsed),
+            vec![vec![18, 124, 255], vec![255, 192, 0]]
+        );
+    }
+
+    #[test]
+    fn skin_combo_colors_falls_back_to_osu_classic_palette() {
+        let parsed = parse_skin_config("[General]\nName: No custom combo colors\n");
+
+        assert_eq!(
+            skin_combo_colors(&parsed),
+            vec![
+                vec![255, 192, 0],
+                vec![0, 202, 0],
+                vec![18, 124, 255],
+                vec![242, 24, 57],
+            ]
+        );
     }
 
     #[test]

--- a/src-tauri/src/local_analysis/service.rs
+++ b/src-tauri/src/local_analysis/service.rs
@@ -2276,7 +2276,7 @@ SliderTickRate:1
     }
 
     #[test]
-    fn cache_recovers_from_backup_and_invalidates_algorithm_changes() {
+    fn cache_recovers_from_backup_and_invalidates_parser_changes() {
         let directory = tempfile::tempdir().expect("cache");
         fs::write(
             service_data::index_path(directory.path(), LocalClient::Stable),
@@ -2295,6 +2295,15 @@ SliderTickRate:1
             serde_json::to_vec(&empty_index("old algorithm")).expect("json"),
         )
         .expect("old backup");
+        assert!(load_index(directory.path(), LocalClient::Stable).is_none());
+
+        let mut old_schema = empty_index(DIFFICULTY_ALGORITHM);
+        old_schema.schema = INDEX_SCHEMA - 1;
+        fs::write(
+            directory.path().join("stable-index.json.bak"),
+            serde_json::to_vec(&old_schema).expect("json"),
+        )
+        .expect("old schema backup");
         assert!(load_index(directory.path(), LocalClient::Stable).is_none());
     }
 

--- a/src-tauri/src/local_analysis/service_data.rs
+++ b/src-tauri/src/local_analysis/service_data.rs
@@ -27,8 +27,8 @@ use super::super::{
 use super::lazer_realm::LazerRealmFile;
 use super::service_query::{compare_beatmaps, compare_skins};
 
-/// Bump this only when a serialized [`LocalIndex`] can no longer be read safely.
-pub(super) const INDEX_SCHEMA: u32 = 7;
+/// 序列化结构或缓存字段语义变化时递增，避免继续复用过期的解析结果。
+pub(super) const INDEX_SCHEMA: u32 = 8;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(super) struct FileStamp {

--- a/src/features/skin-workshop/SkinWorkshopPage.test.tsx
+++ b/src/features/skin-workshop/SkinWorkshopPage.test.tsx
@@ -70,11 +70,14 @@ describe("SkinWorkshopPage", () => {
       { resource_id: "overlay", kind: "image", name: "hitcircleoverlay.png", logical_path: "hitcircleoverlay.png", extension: "png", size: 256, category: "gameplay" },
     ];
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    render(<QueryClientProvider client={queryClient}><SkinWorkshopPage /></QueryClientProvider>);
+    const { container } = render(<QueryClientProvider client={queryClient}><SkinWorkshopPage /></QueryClientProvider>);
 
     expect(screen.getByRole("button", { name: "预览 Refined" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "在本地打开 Refined" })).toBeInTheDocument();
     expect(screen.getByAltText("Refined 光标预览")).toBeInTheDocument();
+    const renderedColors = [...container.querySelectorAll<HTMLElement>("span[style]")].map((element) => element.style.backgroundColor);
+    expect(renderedColors).toContain("rgb(92, 225, 230)");
+    expect(renderedColors).toContain("rgb(255, 106, 167)");
     expect(screen.queryByRole("button", { name: "进入预览" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "本地打开" })).not.toBeInTheDocument();
     mocks.skinItems = [];

--- a/src/features/skin-workshop/SkinWorkshopPage.tsx
+++ b/src/features/skin-workshop/SkinWorkshopPage.tsx
@@ -96,8 +96,9 @@ function SkinCover({ skin, onOpen, onReveal, imported = false }: { skin: LocalSk
   const cursor = useLocalSkinAsset(skin.resource.client, skin.resource.resource_id, cursorSummary?.resource_id ?? null, visible);
   const hitcircle = useLocalSkinAsset(skin.resource.client, skin.resource.resource_id, hitcircleSummary?.resource_id ?? null, visible);
   const overlay = useLocalSkinAsset(skin.resource.client, skin.resource.resource_id, overlaySummary?.resource_id ?? null, visible);
-  const colors = skin.accent_colors.slice(0, 3).map(([red, green, blue]) => `rgb(${red ?? 92} ${green ?? 225} ${blue ?? 230})`);
-  const comboColors = [colors[0] ?? "rgb(92 225 230)", colors[1] ?? "rgb(255 106 167)", colors[2] ?? "rgb(245 181 104)"];
+  const colors = skin.accent_colors.slice(0, 3).map(([red, green, blue]) => `rgb(${red ?? 255} ${green ?? 192} ${blue ?? 0})`);
+  // 与 osu! 经典皮肤的 Combo1～Combo3 默认值保持一致。
+  const comboColors = [colors[0] ?? "rgb(255 192 0)", colors[1] ?? "rgb(0 202 0)", colors[2] ?? "rgb(18 124 255)"];
   return (
     <article className="theme-skin-cover group overflow-hidden rounded-xl border border-white/[0.09] bg-[var(--surface-panel)] transition-colors hover:border-[var(--theme-primary)]/35" ref={cardRef}>
       <button aria-label={`预览 ${skin.name}`} className="relative block h-32 w-full overflow-hidden text-left" onClick={onOpen} type="button">


### PR DESCRIPTION
## 改动目的

修复本地皮肤卡片的 Combo Color 预览与实际皮肤不一致的问题。此前摘要会把 skin.ini 中所有 RGB 配置都当作 Combo Color，导致 MenuGlow、SliderBorder、InputOverlayText 等颜色误用于圆圈预览。

## 改动内容

- `src-tauri/src/local_analysis/parser.rs`
  - 只读取 `[Colours]` 下的 `Combo1`～`Combo8`
  - 按配置文件中的实际出现顺序保留自定义 Combo Color
  - 忽略 alpha，预览仅使用 RGB
  - 未配置 Combo Color 时回退到 osu! 经典默认四色
  - 增加提取范围、顺序与默认色测试
- `src-tauri/src/local_analysis/service_data.rs`
  - 提升本地索引版本，使旧版错误颜色缓存自动失效并重新扫描
- `src-tauri/src/local_analysis/service.rs`
  - 补充旧索引版本失效测试
- `src/features/skin-workshop/SkinWorkshopPage.tsx`
  - 前端缺省颜色同步为 osu! 经典 Combo1～Combo3
- `src/features/skin-workshop/SkinWorkshopPage.test.tsx`
  - 验证卡片使用摘要返回的真实 Combo Color

## 验证

- `pnpm test`：41 个测试文件、118 项测试全部通过
- `pnpm lint`：通过
- `pnpm build`：通过
- `git diff --check`：通过

本机未安装 Rust 工具链，Rust 编译与测试由仓库 CI 继续验证。